### PR TITLE
Push Docker image to ghcr.io

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,53 @@
+name: Build and publish a Docker image to ghcr.io
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+jobs:
+  docker_publish:
+    runs-on: "ubuntu-20.04"
+
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+      -
+        name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm64

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ sudo systemctl start tl-sg-prometheus-exporter
 sudo journalctl -f -u tl-sg-prometheus-exporter
 ```
 
+# Docker
+A Docker image is provided. You can run it with a command like:
+```
+docker run -it -p 8000:8000 -v /path/to/tl-sg-prometheus-exporter.yaml:/app/config.yaml ghcr.io/mad-ady/tl-sg-prometheus-exporter
+```
+
+Where `/path/to/tl-sg-prometheus-exporter.yaml` is the location of your configuration YAML file.
+
 # Security and future improvements
 Traffic to the switches uses plain HTTP. The password is also sent in clear-text (as a HTTP POST request). When `cache_login: False`, the script logs in each time it needs to get the metrics. This is because of how the switches are designed to operate. In insecure environments consider tunneling the traffic through ssh tunnels (though traffic will still be unencrypted when it reaches the switch). 
 The passwords are also stored in clear-text inside the configuration file.

--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ sudo journalctl -f -u tl-sg-prometheus-exporter
 # Docker
 A Docker image is provided. You can run it with a command like:
 ```
-docker run -it -p 8000:8000 -v /path/to/tl-sg-prometheus-exporter.yaml:/app/config.yaml ghcr.io/mad-ady/tl-sg-prometheus-exporter
+docker run -it -p 8000:8000 -v /path/to/tl-sg-prometheus-exporter.yaml:/app/config.yaml ghcr.io/mad-ady/tl-sg-prometheus-exporter:main
 ```
 
 Where `/path/to/tl-sg-prometheus-exporter.yaml` is the location of your configuration YAML file.
+
+The container image is currently built for AMD64 and ARM64 architectures.
 
 # Security and future improvements
 Traffic to the switches uses plain HTTP. The password is also sent in clear-text (as a HTTP POST request). When `cache_login: False`, the script logs in each time it needs to get the metrics. This is because of how the switches are designed to operate. In insecure environments consider tunneling the traffic through ssh tunnels (though traffic will still be unencrypted when it reaches the switch). 


### PR DESCRIPTION
Thanks for building this. It's at first glance working great on my SG105E switches (v3 and v5) without any changes, although I haven't run it "in anger" yet, so will report back with a README update when I have some more confidence. 😄 

This PR just builds and pushes the existing Dockerfile to GitHub's Container Registry for a couple of different architectures, so there's no need to do any Docker builds to get going with it. 